### PR TITLE
Setting unification/simplification

### DIFF
--- a/brostar_api/celery.py
+++ b/brostar_api/celery.py
@@ -1,5 +1,8 @@
+import os
+
 from celery import Celery
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brostar_api.settings")
 app = Celery("brostar_api")
 
 # Using a string here means the worker doesn't have to serialize

--- a/brostar_api/settings.py
+++ b/brostar_api/settings.py
@@ -15,7 +15,7 @@ NENS_AUTH_CLIENT_SECRET = os.getenv("NENS_AUTH_CLIENT_SECRET")
 DEBUG_ENV = os.getenv("DEBUG", default="true")
 
 # Convert the environment variable (which is a string) to a boolean.
-DEBUG = (DEBUG_ENV.lower() == "true")  # True is the default
+DEBUG = DEBUG_ENV.lower() == "true"  # True is the default
 
 
 TIME_ZONE = "CET"

--- a/brostar_api/settings.py
+++ b/brostar_api/settings.py
@@ -1,30 +1,29 @@
 import os
 from pathlib import Path
 
-FIELD_ENCRYPTION_KEY = os.getenv("FIELD_ENCRYPTION_KEY")
+# Environment variables can get a default value from an .env file via docker-compose.
+FIELD_ENCRYPTION_KEY = os.getenv(
+    "FIELD_ENCRYPTION_KEY", default="DUMMY-NEEDS-PROD-SETTING-Xgb1GczqZe909UMNc4="
+)
+SECRET_KEY = os.getenv(
+    "SECRET_KEY",
+    default="django-insecure-r4_51z=)9re0wxnj(fwanhzi($42k#usdr37z!o2c-a04*4p06",
+)
 NENS_AUTH_ISSUER = os.getenv("NENS_AUTH_ISSUER")
 NENS_AUTH_CLIENT_ID = os.getenv("NENS_AUTH_CLIENT_ID")
 NENS_AUTH_CLIENT_SECRET = os.getenv("NENS_AUTH_CLIENT_SECRET")
-# Environment variables can get a default value from docker-compose itself *or* from a
-# `.env` file, as docker-compose automatically reads that (if the environment variable
-# itself is mentioned in the compose file).
+DEBUG_ENV = os.getenv("DEBUG", default="true")
+
+# Convert the environment variable (which is a string) to a boolean.
+DEBUG = (DEBUG_ENV.lower() == "true")  # True is the default
+
 
 TIME_ZONE = "CET"
 USE_TZ = True
 
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-r4_51z=)9re0wxnj(fwanhzi($42k#usdr37z!o2c-a04*4p06"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
 ALLOWED_HOSTS = []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       POSTGRES_DB: 'brostar'
     volumes:
       - pgdata:/var/lib/postgresql/data
-    restart: unless-stopped
 
   redis:
     image: redis:latest
@@ -19,8 +18,9 @@ services:
 
   celery:
     environment:
-      - DJANGO_SETTINGS_MODULE=brostar_api.settings
-      - FIELD_ENCRYPTION_KEY="DUMMY-NEEDS-PROD-SETTING-Xgb1GczqZe909UMNc4="
+      # # Can be set in .env, we'll pass them on. settings.py has some defaults.
+      - FIELD_ENCRYPTION_KEY
+      - SECRET_KEY
       - NENS_AUTH_ISSUER
       - NENS_AUTH_CLIENT_ID
       - NENS_AUTH_CLIENT_SECRET
@@ -35,6 +35,13 @@ services:
       - redis
 
   web:
+    environment:
+      # # Can be set in .env, we'll pass them on. settings.py has some defaults.
+      - FIELD_ENCRYPTION_KEY
+      - SECRET_KEY
+      - NENS_AUTH_ISSUER
+      - NENS_AUTH_CLIENT_ID
+      - NENS_AUTH_CLIENT_SECRET
     build: .
     # command: "bin/gunicorn -b 0.0.0.0:${PORT:-5000} --workers=3 --timeout 90 --preload --max-requests=10000 trs.wsgi"
     command: "python manage.py runserver 0.0.0.0:8000"
@@ -44,21 +51,10 @@ services:
       - "8000:8000"
     volumes:
       - .:/code
-    restart: unless-stopped
-    environment:
-      # # Can be set in .env, we'll pass them on.
-      # - SECRET_KEY
-      - DEBUG
-      - FIELD_ENCRYPTION_KEY="DUMMY-NEEDS-PROD-SETTING-Xgb1GczqZe909UMNc4="
-      # - SENTRY_DSN
-      - NENS_AUTH_ISSUER
-      - NENS_AUTH_CLIENT_ID
-      - NENS_AUTH_CLIENT_SECRET
     depends_on:
       - db
       - redis
       - celery
-
 
 
 volumes:


### PR DESCRIPTION
- Defaults are in `settings.py` instead of docker-compose.
- `SECRET_KEY` and `DEBUG` are now also settable via env vars.
- Made env var handling the same for "web" and "celery".