### PR TITLE
hotfix organisations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 1.76 (unreleased)
 
 
--   Hotfix [Organisations]: limit users ability within the API surrounding organisations to prevent a user from one organisation from deleting other organisations.
+-   Hotfix [Organisations]: limit users ability within the API surrounding organisations to prevent a user from one organisation from deleting other organisations. [Thanks to Ray Sabee @whitehatsecurity.nl]
 
 
 ## 1.75 (2026-06-18)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 1.76 (unreleased)
 
 
-- Nothing changed yet.
+-   Hotfix [Organisations]: limit users ability within the API surrounding organisations to prevent a user from one organisation from deleting other organisations.
 
 
 ## 1.75 (2026-06-18)

--- a/api/mixins.py
+++ b/api/mixins.py
@@ -3,6 +3,7 @@ from typing import Any
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django_filters import rest_framework as filters
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.reverse import reverse
 
 from api import models as api_models
@@ -18,6 +19,22 @@ class UserOrganizationMixin:
         user_organization = self.get_user_organisation()
         queryset = super().get_queryset()  # type: ignore
         return queryset.filter(data_owner=user_organization)
+
+    def perform_create(self, serializer):
+        # Force data_owner to the requesting user's org, ignoring
+        # (or rejecting) any value the client tried to submit.
+        serializer.save(data_owner=self.get_user_organisation())
+
+    def perform_update(self, serializer):
+        # Prevent a PATCH/PUT from reassigning the object to another org.
+        serializer.save(data_owner=self.get_user_organisation())
+
+    def perform_destroy(self, instance):
+        # Belt-and-suspenders: get_object() already filtered by org,
+        # but this guards against get_object() being overridden elsewhere.
+        if instance.data_owner_id != self.get_user_organisation().id:
+            raise PermissionDenied("Not allowed to delete this object.")
+        super().perform_destroy(instance)
 
 
 class UrlFieldMixin:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,7 +15,7 @@ class UserSerializer(serializers.ModelSerializer):
 class OrganisationSerializer(serializers.ModelSerializer):
     class Meta:
         model = api_models.Organisation
-        fields = "__all__"
+        fields = ["name", "kvk_number"]
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/api/views.py
+++ b/api/views.py
@@ -215,9 +215,10 @@ class OrganisationViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.OrganisationSerializer
     lookup_field = "uuid"
     queryset = models.Organisation.objects.all().order_by("name")
+    http_method_names = ["get", "head", "patch", "options"]
 
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = "__all__"
+    filterset_fields = ["uuid", "name", "kvk_number"]
 
     def update(self, request, *args, **kwargs):
         # validate that the user requests the change for own organisation

--- a/api/views.py
+++ b/api/views.py
@@ -386,10 +386,9 @@ class UploadTaskViewSet(mixins.UserOrganizationMixin, viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Always enforce the organisation from the user
-        serializer.validated_data["data_owner"] = user_profile.organisation
-
-        self.perform_create(serializer)
+        # Always enforce the organisation from the user, pass as kwarg so DRF
+        # merges it into validated_data after read-only field filtering.
+        serializer.save(data_owner=user_profile.organisation)
         headers = self.get_success_headers(serializer.data)
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
@@ -409,8 +408,7 @@ class UploadTaskViewSet(mixins.UserOrganizationMixin, viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        serializer.validated_data["data_owner"] = user_profile.organisation
-        self.perform_update(serializer)
+        serializer.save(data_owner=user_profile.organisation)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "brostar-api"
-version = "1.73.dev0"
+version = "1.76.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "celery", extra = ["redis"] },


### PR DESCRIPTION
Through the organisations endpoint, a user was able to find uuid's of other organisations.
This resulted in a user being able to access the detail page of an organisation, and possibly delete the record.

- Organisations only show their core information, which is relevant for others: kvk and name. Users from an organisation can still access their org through the uuid linked with their own 'data_owner' label.

- Organisations can now only be deleted by admins, through the admin interface
